### PR TITLE
Fix "polyphonic" control-port preset values.

### DIFF
--- a/bundles/mod-mda-EPiano.lv2/presets.ttl
+++ b/bundles/mod-mda-EPiano.lv2/presets.ttl
@@ -40,7 +40,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "polyphonic" ;
-		pset:value 0.5 ;
+		pset:value 1.0 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine_tuning" ;
@@ -93,7 +93,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "polyphonic" ;
-		pset:value 0.5 ;
+		pset:value 1.0 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine_tuning" ;
@@ -146,7 +146,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "polyphonic" ;
-		pset:value 0.5 ;
+		pset:value 1.0 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine_tuning" ;
@@ -199,7 +199,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "polyphonic" ;
-		pset:value 0.5 ;
+		pset:value 1.0 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine_tuning" ;
@@ -252,7 +252,7 @@
 	] ;
 	lv2:port [
 		lv2:symbol "polyphonic" ;
-		pset:value 0.5 ;
+		pset:value 1.0 ;
 	] ;
 	lv2:port [
 		lv2:symbol "fine_tuning" ;


### PR DESCRIPTION
"polyphonic" is an integer/toggle control port, with min.value=0 and max.value=1, so "0.5" value has no sense. "1.0" should be the right value for these presets.